### PR TITLE
[Fix] Modify firebase_core to fix iOS error

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,7 +266,7 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.4+3"
+    version: "0.4.4"
   firebase_core_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
   #gzx_dropdown_menu: ^1.0.3
 
   # Firebase
-  firebase_core: ^0.4.0+9
+  firebase_core: 0.4.4  # 0.4.4+3 版本在 iOS 尚有問題
   firebase_analytics: ^5.0.11
   firebase_crashlytics: ^0.1.3+2
 


### PR DESCRIPTION
## Summary
`firebase_core (0.4.4+3)`  會讓 iOS build 失敗，因此將版本將到 `0.4.4`