### PR TITLE
Fix video playback on istream.ntut.edu.tw

### DIFF
--- a/lib/ui/pages/videoplayer/class_video_player.dart
+++ b/lib/ui/pages/videoplayer/class_video_player.dart
@@ -158,8 +158,10 @@ class _VideoPlayer extends State<ClassVideoPlayer> {
   }
 
   Future<void> initController(Uri url) async {
+    final headers = await Connector.getLoginHeaders(url.toString()) ?? {};
     _playerController = VideoPlayerController.networkUrl(
       url,
+      httpHeaders: headers,
       videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
     );
 


### PR DESCRIPTION
The video player was creating network requests to `istream.ntut.edu.tw` without any authentication cookies or headers. The native `VideoPlayerController` uses its own HTTP client, separate from the app's authenticated Dio instance, so the server rejected requests with a 404.

This passes the session cookies and headers from `Connector.getLoginHeaders()` to `VideoPlayerController.networkUrl()` via the `httpHeaders` parameter.

Fixes playback on both iOS (`PlatformException: Failed to load video`) and Android (ExoPlayer crash).

Closes #109
Closes #110